### PR TITLE
update some props for webpack@2

### DIFF
--- a/config/common.webpack.conf.js
+++ b/config/common.webpack.conf.js
@@ -29,7 +29,7 @@ module.exports = {
         {
           enforce: 'pre',
           test: /\.ts$/,
-          loader: 'tslint',
+          use: 'tslint-loader',
           exclude: [
             /node_modules/,
             /\.(spec|e2e)\.ts$/
@@ -38,38 +38,47 @@ module.exports = {
         {
           enforce: 'pre',
           test: /\.js$/,
-          loader: 'source-map'
+          use: 'source-map-loader'
         },
         {
           test: /\.ts$/,
-          loader: 'awesome-typescript',
+          use: 'awesome-typescript-loader',
           exclude: [ /\.(spec|e2e)\.ts$/ ]
         },
         {
-          test: /\.json$/,
-          loader: 'json'
-        },
-        {
           test: /\.html$/,
-          loader: 'raw',
+          use: 'raw-loader',
           exclude: [ helpers.root('src/index.html') ]
         },
         {
           test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
-          loader: 'file?name=assets/[name].[hash].[ext]'
+          use: 'file-loader?name=assets/[name].[hash].[ext]'
         },
         {
           test: /\.scss/,
-          loader: 'raw!postcss?sourceMap!sass?sourceMap',
+          use: [
+            'raw-loader',
+            'postcss-loader?sourceMap',
+            'sass-loader?sourceMap'
+          ],
           include: helpers.root('src/app')
         },
         {
           test: /main\.scss/,
-          loader: 'style!css!postcss!sass'
+          use: [
+            'style-loader',
+            'css-loader',
+            'postcss-loader',
+            'sass-loader'
+          ]
         },
         {
           test: /\.css/,
-          loader: 'style!css!postcss'
+          use: [
+            'style-loader',
+            'css-loader',
+            'postcss-loader'
+          ]
         }
       ],
       noParse: [

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "file-loader": "0.9.0",
     "import-glob-loader": "1.1.0",
     "imports-loader": "0.6.5",
-    "json-loader": "0.5.4",
     "raw-loader": "0.5.1",
     "source-map-loader": "0.1.5",
     "tslint-loader": "2.1.5",
@@ -92,8 +91,8 @@
     "compression-webpack-plugin": "0.3.1",
     "copy-webpack-plugin": "3.0.1",
 
-    "webpack": "2.1.0-beta.25",
-    "webpack-dev-server": "2.1.0-beta.6",
+    "webpack": "2.2.1",
+    "webpack-dev-server": "2.2.0",
     "webpack-md5-hash": "0.0.5",
     "webpack-merge": "0.14.1"
   },


### PR DESCRIPTION
- Обновлены правила: loader > use
- Обновлены версии  webpack; webpack-dev-server
- Убран json-loader (включен в вебпак2 по умолчанию)

обновлено в соответствии с [migraton manifest](https://webpack.js.org/guides/migrating/)